### PR TITLE
breakpoint-min backwards compatibility fix

### DIFF
--- a/src/sass/mixins/_breakpoint.scss
+++ b/src/sass/mixins/_breakpoint.scss
@@ -1,20 +1,20 @@
 /*
  * Media query shorthand, to be used with variables from $site-breakpoints
  * Defaults to min-width
- * 
+ *
  * Usage: @include mq(lg, min/max(optional) ) { ... }
  */
 
 @function breakpoint-min($name, $breakpoints: $site-breakpoints) {
   $min: map-get($breakpoints, $name);
-  @return if($min != 0, $min, null);
+  @return max(0, $min);
 }
 
 @mixin mq($name, $type: min) {
   $min: breakpoint-min($name);
 
   @if ($min > 0) {
-    @if $type == max {
+    @if ($type == max) {
       $min: $min - 1px;
     }
 


### PR DESCRIPTION
@ZeroSpree This fix should be compatible with dart-sass and node-sass. The last change to this file (for dart-sass compatibility) broke builds running node-sass.